### PR TITLE
pass source to `nixpacks`

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -39,7 +39,6 @@ func (b *Builder) BuildFunc() interface{} {
 }
 
 const (
-	DEFAULT_SOURCE   = "./"
 	DEFAULT_PLATFORM = "linux/amd64"
 )
 
@@ -55,12 +54,15 @@ func (b *Builder) Build(
 
 	// set config defaults
 	if b.config.Source == "" {
-		b.config.Source = DEFAULT_SOURCE
+		// this should be the directory where the waypoint.hcl file is located
+		b.config.Source = src.Path
 	}
 
 	if b.config.Platform == "" {
 		b.config.Platform = DEFAULT_PLATFORM
 	}
+
+	log.Info("config values", "source", b.config.Source, "platform", b.config.Platform)
 
 	// check for nixpack
 	nixpacksPath, err := exec.LookPath("nixpacks")

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -72,7 +72,7 @@ func (b *Builder) Build(
 	u.Step(terminal.StatusOK, fmt.Sprintf("Nixpacks installed at: %q", nixpacksPath))
 
 	cmd := exec.Command(nixpacksPath,
-		"build", ".",
+		"build", b.config.Source,
 		"--platform", b.config.Platform,
 		"--name", fmt.Sprintf("waypoint.local/%s", src.App))
 


### PR DESCRIPTION
# Description

This makes use of the `source` config value, and passes it to `nixpacks`

The use case this addresses is when the `waypoint-plugin-nixpacks` binary is located in `$HOME/.config/waypoint/plugins/waypoint-plugin-nixpacks`, which causes the previous default, `./`, to resolve incorrectly.

